### PR TITLE
Add some tests to check that only the appropriate listeners are called.

### DIFF
--- a/test.lua
+++ b/test.lua
@@ -18,6 +18,9 @@ end)
 anotherListener = conversation:listen('set arbitrary number', function(n)
   return n * 2
 end)
+notUsedListener = conversation:listen('not called', function(n)
+  assert(false, 'I should not be called')
+end)
 a, b, c = conversation:say('set arbitrary number', 5)
 
 assert(arbitraryNumber == 5,
@@ -28,6 +31,7 @@ assert(a == 5 and b == 7 and c == 10,
 --stop listening function
 conversation:stopListening(setNumberListener)
 conversation:stopListening(anotherListener)
+conversation:stopListening(notUsedListener)
 d, e, f = conversation:say('set arbitrary number', 7)
 
 assert(not (d or e or f),
@@ -41,6 +45,9 @@ group:listen('set arbitrary number', function(n)
 end)
 group:listen('set arbitrary number', function(n)
   return n * 2
+end)
+group:listen('not called', function(n)
+  assert(false, 'I should not be called')
 end)
 
 a, b, c = conversation:say('set arbitrary number', 10)


### PR DESCRIPTION
There was a bug on my end where multiple `listen` calls were being called for a single `say` (because the signal that was being listened for/passed in was actually `nil`). I noticed you didn't have any tests for this so I added them in.
